### PR TITLE
Fix `make` and `make test` targets

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -20,6 +20,7 @@ $O/libdyaml.a: $(shell find $C/submodules/d-yaml/source -type f -name '*.d') \
 ################################################################################
 
 $O/%unittests: override LDFLAGS += -L$O -lvibed -ldyaml -levent -lssl -lcrypto
+test: $O/libvibed.a $O/libdyaml.a
 
 $B/overview: $O/libvibed.a $O/libdyaml.a
 $B/overview: $C/src/overview/main.d


### PR DESCRIPTION
The static libraries were missing as dependency