### PR TITLE
Replace pipeShell with pipeProcess and other e-mail fixes

### DIFF
--- a/integrationtest/common/TestCase.d
+++ b/integrationtest/common/TestCase.d
@@ -283,7 +283,17 @@ class TestCase
 
         auto test_mail = strip(content[0]);
         auto correct_mail = git.cmd(format("tail %s/%s -n+2", data, file));
-        assert(test_mail == correct_mail, "Generated Email is incorrect");
+        if (test_mail != correct_mail)
+        {
+            import std.stdio;
+            writeln("Generated Email is incorrect");
+            writeln("--------------------- bad --------------------------");
+            write(test_mail);
+            writeln("--------------------- good -------------------------");
+            write(correct_mail);
+            writeln("--------------------- end --------------------------");
+            assert(false);
+        }
     }
 
     /// Checks the termination status & code of neptune-process

--- a/integrationtest/common/shellHelper.d
+++ b/integrationtest/common/shellHelper.d
@@ -18,7 +18,27 @@ module integrationtest.common.shellHelper;
 
     Params:
         wd = directory to run the command in
-        command = command to run
+        command = command to run and arguments to pass to it
+
+    Returns:
+        output of the command
+
+*******************************************************************************/
+
+string cmd ( string wd, const(string[]) command )
+{
+    int status;
+    return cmd(wd, command, status);
+}
+
+/*******************************************************************************
+
+    Runs a command and returns the output
+
+    Params:
+        wd = directory to run the command in
+        command = command to run (including arguments). Arguments will be split
+                  based on spaces
 
     Returns:
         output of the command
@@ -28,13 +48,7 @@ module integrationtest.common.shellHelper;
 string cmd ( string wd, string command )
 {
     int status;
-
-    auto output = cmd(wd, command, status);
-
-    if (status != 0)
-        throw new Exception(output);
-
-    return output;
+    return cmd(wd, command, status);
 }
 
 /*******************************************************************************
@@ -43,7 +57,8 @@ string cmd ( string wd, string command )
 
     Params:
         wd = directory to run the command in
-        command = command to run
+        command = command to run (including arguments). Arguments will be split
+                  based on spaces
         status = the return status of the command will be written to this out
                  parameter
 
@@ -54,13 +69,34 @@ string cmd ( string wd, string command )
 
 string cmd ( string wd, string command, out int status )
 {
-    import std.process : executeShell, Config;
+    import std.string: split;
+    return cmd(wd, command.split(), status);
+}
+
+/*******************************************************************************
+
+    Runs a command and returns the output
+
+    Params:
+        wd = directory to run the command in
+        command = command to run and arguments to pass to it
+        status = the return status of the command will be written to this out
+                 parameter
+
+    Returns:
+        output of the command
+
+*******************************************************************************/
+
+string cmd ( string wd, const(string[]) command, out int status )
+{
+    import std.process : execute, Config;
     import std.string : strip;
 
     string[string] env;
     env["HOME"] = wd;
 
-    auto c = executeShell(command, env, Config.none, size_t.max, wd);
+    auto c = execute(command, env, Config.none, size_t.max, wd);
 
     status = c.status;
 

--- a/integrationtest/initial_release/data/mail.txt
+++ b/integrationtest/initial_release/data/mail.txt
@@ -1,4 +1,5 @@
 First line is skipped
+To: dummy@notexisting.example
 Subject: [MajorRelease] sandbox v1.0.0
 
 

--- a/integrationtest/initial_release/data/mail.txt
+++ b/integrationtest/initial_release/data/mail.txt
@@ -57,3 +57,4 @@ Features
 
 
 http://github.com/tester/sandbox/releases/tag/v1.0.0
+

--- a/integrationtest/prerelease/data/mail-v1.0.0-rc1.txt
+++ b/integrationtest/prerelease/data/mail-v1.0.0-rc1.txt
@@ -57,3 +57,4 @@ Features
 
 
 http://github.com/tester/sandbox/releases/tag/v1.0.0-rc1
+

--- a/integrationtest/prerelease/data/mail-v1.0.0-rc1.txt
+++ b/integrationtest/prerelease/data/mail-v1.0.0-rc1.txt
@@ -1,4 +1,5 @@
 First line is skipped
+To: dummy@notexisting.example
 Subject: [MajorRelease] sandbox v1.0.0-rc1
 
 

--- a/integrationtest/prerelease/data/mail-v1.0.0-rc2.txt
+++ b/integrationtest/prerelease/data/mail-v1.0.0-rc2.txt
@@ -1,4 +1,5 @@
 First line is skipped
+To: dummy@notexisting.example
 Subject: [MajorRelease] sandbox v1.0.0-rc2
 
 

--- a/integrationtest/prerelease/data/mail-v1.0.0-rc2.txt
+++ b/integrationtest/prerelease/data/mail-v1.0.0-rc2.txt
@@ -57,3 +57,4 @@ Features
 
 
 http://github.com/tester/sandbox/releases/tag/v1.0.0-rc2
+

--- a/integrationtest/prerelease/data/mail-v1.0.0.txt
+++ b/integrationtest/prerelease/data/mail-v1.0.0.txt
@@ -1,4 +1,5 @@
 First line is skipped
+To: dummy@notexisting.example
 Subject: [MajorRelease] sandbox v1.0.0
 
 

--- a/integrationtest/prerelease/data/mail-v1.0.0.txt
+++ b/integrationtest/prerelease/data/mail-v1.0.0.txt
@@ -57,3 +57,4 @@ Features
 
 
 http://github.com/tester/sandbox/releases/tag/v1.0.0
+

--- a/integrationtest/prerelease/data/mail-v1.1.0-rc1.txt
+++ b/integrationtest/prerelease/data/mail-v1.1.0-rc1.txt
@@ -59,3 +59,4 @@ Features
 
 
 http://github.com/tester/sandbox/releases/tag/v1.1.0-rc1
+

--- a/integrationtest/prerelease/data/mail-v1.1.0-rc1.txt
+++ b/integrationtest/prerelease/data/mail-v1.1.0-rc1.txt
@@ -1,4 +1,5 @@
 First line is skipped
+To: dummy@notexisting.example
 Subject: [MinorRelease] sandbox v1.1.0-rc1
 
 If your application is using a previous sandbox v1.x.x release, it is recommended to update it to use this new minor release. As this is a minor release, it may contain new features, deprecations, or minor internal refactorings; it is guaranteed to not contain API changes and will not require you to change your code.

--- a/integrationtest/prerelease/data/mail-v1.1.0-rc2.txt
+++ b/integrationtest/prerelease/data/mail-v1.1.0-rc2.txt
@@ -59,3 +59,4 @@ Features
 
 
 http://github.com/tester/sandbox/releases/tag/v1.1.0-rc2
+

--- a/integrationtest/prerelease/data/mail-v1.1.0-rc2.txt
+++ b/integrationtest/prerelease/data/mail-v1.1.0-rc2.txt
@@ -1,4 +1,5 @@
 First line is skipped
+To: dummy@notexisting.example
 Subject: [MinorRelease] sandbox v1.1.0-rc2
 
 If your application is using a previous sandbox v1.x.x release, it is recommended to update it to use this new minor release. As this is a minor release, it may contain new features, deprecations, or minor internal refactorings; it is guaranteed to not contain API changes and will not require you to change your code.

--- a/integrationtest/prerelease/data/mail-v1.1.0.txt
+++ b/integrationtest/prerelease/data/mail-v1.1.0.txt
@@ -1,4 +1,5 @@
 First line is skipped
+To: dummy@notexisting.example
 Subject: [MinorRelease] sandbox v1.1.0
 
 If your application is using a previous sandbox v1.x.x release, it is recommended to update it to use this new minor release. As this is a minor release, it may contain new features, deprecations, or minor internal refactorings; it is guaranteed to not contain API changes and will not require you to change your code.

--- a/integrationtest/prerelease/data/mail-v1.1.0.txt
+++ b/integrationtest/prerelease/data/mail-v1.1.0.txt
@@ -59,3 +59,4 @@ Features
 
 
 http://github.com/tester/sandbox/releases/tag/v1.1.0
+

--- a/integrationtest/prerelease/main.d
+++ b/integrationtest/prerelease/main.d
@@ -33,6 +33,7 @@ class Prerelease : TestCase
     protected void testMajor ( )
     {
         import integrationtest.common.shellHelper;
+        import std.stdio: toFile;
 
         this.prepareGitRepo();
         this.prepareRelNotes("v1.x.x");
@@ -40,9 +41,9 @@ class Prerelease : TestCase
         this.testReleaseCandidate(0, 1);
 
         // simulate some changes fo rc 2
-        git.cmd("echo bla > somefile.txt");
+        toFile("bla", "somefile.txt");
         git.cmd("git add somefile.txt");
-        git.cmd(`git commit -m "Add some file"`);
+        git.cmd(["git", "commit", "-m", "Add some file"]);
 
         this.testReleaseCandidate(0, 2);
 
@@ -53,15 +54,16 @@ class Prerelease : TestCase
     protected void testMinor ( )
     {
         import integrationtest.common.shellHelper;
+        import std.stdio: toFile;
 
         this.prepareGitRepo();
         this.fake_github.reset();
 
         // Create a v1.0.0 dummy
         git.cmd("git checkout -B v1.x.x");
-        git.cmd("echo bla > somefile.txt");
+        toFile("bla", "somefile.txt");
         git.cmd("git add somefile.txt");
-        git.cmd(`git commit -m "Add some file"`);
+        git.cmd(["git", "commit", "-m", "Add some file"]);
         git.cmd(`git tag -a v1.0.0 -m v1.0.0`);
 
         auto sha = git.cmd("git rev-parse v1.0.0");
@@ -76,9 +78,9 @@ class Prerelease : TestCase
         this.testReleaseCandidate(1, 1);
 
         // simulate some changes fo rc 2
-        git.cmd("echo bla > somefile2.txt");
+        toFile("bla", "somefile2.txt");
         git.cmd("git add somefile2.txt");
-        git.cmd(`git commit -m "Add some file2"`);
+        git.cmd(["git", "commit", "-m", "Add some file2"]);
 
         this.testReleaseCandidate(1, 2);
 

--- a/src/release/actions.d
+++ b/src/release/actions.d
@@ -40,6 +40,7 @@ interface Action
     string description ( ) const;
 
     /// Returns the command the action does
+    /// (only for display, to execute the command use execute())
     string command ( ) const;
 }
 
@@ -102,7 +103,7 @@ struct ActionList
 class LocalAction : Action
 {
     /// The command this action is going to run
-    string _command;
+    const(string[]) _cmd_list;
 
     /// The description of this command
     string _description;
@@ -118,9 +119,9 @@ class LocalAction : Action
 
     ***************************************************************************/
 
-    this ( string command, string description )
+    this ( const(string[]) command, string description )
     {
-        this._command = command;
+        this._cmd_list = command;
         this._description = description;
     }
 
@@ -138,7 +139,7 @@ class LocalAction : Action
         import release.shellHelper;
         import std.string : strip;
 
-        return strip(cmd(this.command()));
+        return strip(cmd(this._cmd_list));
     }
 
     /***************************************************************************
@@ -156,12 +157,15 @@ class LocalAction : Action
     /***************************************************************************
 
         Returns:
-            command to be run
+            command to be run and its arguments
 
     ***************************************************************************/
 
     override string command ( ) const
     {
-        return this._command;
+        import std.string: join;
+        return this._cmd_list.join(" ");
     }
+
+
 }

--- a/src/release/gitHelper.d
+++ b/src/release/gitHelper.d
@@ -150,7 +150,7 @@ string getTagMessage ( string tag )
     import std.format;
     import std.algorithm.searching : findSplitBefore;
 
-    auto result = cmd(format("git cat-file %s -p | tail -n+6", tag));
+    auto result = cmd(["git", "cat-file", tag, "-p"]).linesFrom(6);
 
     return result.findSplitBefore("\n-----BEGIN PGP SIGNATURE-----")[0];
 }

--- a/src/release/main.d
+++ b/src/release/main.d
@@ -198,13 +198,13 @@ void main ( string[] params )
         }
     }
 
-    auto email_body = craftMail(con, repo, myrelease.type,
+    auto email = craftMail(con, repo, myrelease.type,
         list.actions
             .map!(a=>cast(ReleaseAction) a)
             .filter!(a=>a !is null)
             .array);
 
-    writefln("This is the announcement email:\n-----\n%s\n-----", email_body);
+    writefln("This is the announcement email:\n-----\n%s\n-----", email);
 
     auto recp = getConfig("neptune.mail-recipient").ifThrown("");
 
@@ -213,7 +213,7 @@ void main ( string[] params )
     if (!opts.no_send_mail &&
         getBoolChoice("Would you like to send it to %s now?", recp))
     {
-        sendMail(email_body, recp);
+        sendMail(email, recp);
     }
 
     writefln("All done.");
@@ -279,12 +279,12 @@ string getMilestoneLink ( HTTPConnection con, Repository repo, string ver )
     Sends the announcement email
 
     Params:
-        full_body = complete body of the email, including From & Subject line
+        email = complete email, including headers and body
         recipient = recipient email
 
 *******************************************************************************/
 
-void sendMail ( string full_body, string recipient )
+void sendMail ( string email, string recipient )
 {
     import release.gitHelper;
 
@@ -298,7 +298,7 @@ void sendMail ( string full_body, string recipient )
     auto proc = pipeShell(format("%s %s", sendmailbin, recipient),
                           Redirect.all);
 
-    proc.stdin.write(full_body);
+    proc.stdin.write(email);
     proc.stdin.flush();
     proc.stdin.close();
 

--- a/src/release/mergeHelper.d
+++ b/src/release/mergeHelper.d
@@ -33,8 +33,8 @@ class MergeAction : LocalAction
     {
         import std.format;
 
-        super(format(`git merge --no-ff -m "Merge tag %s into %s" %s`,
-                     tag, target, tag),
+        super(["git", "merge", "--no-ff", "-m",
+                format("Merge tag %s into %s", tag, target), tag],
               format("Merge %s into %s", tag, target));
     }
 
@@ -403,8 +403,7 @@ ActionList checkoutMerge ( in Version merge, in SemVerBranch checkout )
 
     ActionList list;
 
-    list.actions ~= new LocalAction(format("git checkout %s",
-                                           checkout),
+    list.actions ~= new LocalAction(["git", "checkout", checkout.toString],
                                     format("Checkout %s locally", checkout));
     list.actions ~= new MergeAction(checkout.toString, merge.toString);
 

--- a/src/release/releaseHelper.d
+++ b/src/release/releaseHelper.d
@@ -84,7 +84,7 @@ class ReleaseAction : Action
 
         assert(tag_msg.length > 0, "No release notes found?!");
 
-        auto proc = pipeShell(this.command, Redirect.all);
+        auto proc = pipeProcess(this._cmd_list);
 
         proc.stdin.write(tag_msg);
         proc.stdin.flush();
@@ -110,10 +110,15 @@ class ReleaseAction : Action
     /// Returns command of this action
     override string command ( ) const
     {
-        import std.format;
-        return format("git tag -F- %s %s",
-                      this.tag_version,
-                      this.tag_reference);
+        import std.string: join;
+        return this._cmd_list.join(" ");
+    }
+
+    /// Returns command list of this action
+    protected const(string[]) _cmd_list ( ) const
+    {
+        return ["git", "tag", "-F-", this.tag_version.toString,
+               this.tag_reference];
     }
 }
 
@@ -265,7 +270,7 @@ ActionList makeRelease ( Version release_version, string target,
         auto branch = SemVerBranch(major, minor);
 
         // Create the appropriate branch
-        list.actions ~= new LocalAction(format("git branch %s %s", branch, v),
+        list.actions ~= new LocalAction(["git", "branch", branch.toString, v],
                                         format("Create tracking branch %s",
                                                  branch));
 

--- a/src/release/shellHelper.d
+++ b/src/release/shellHelper.d
@@ -34,10 +34,58 @@ class ExitCodeException : Exception
 
 /*******************************************************************************
 
+    Emulates "tail -n+<n>" (gets the lines from <n> till the end)
+
+    This can also be seen as a line-based slice "text[n-1..$]".
+
+    Params:
+        text = text to get the tail from
+        n = starting line to get from text
+
+    Returns:
+        line-sliced text
+
+*******************************************************************************/
+
+string linesFrom ( string text, size_t n )
+{
+    import std.string: splitLines, join, Yes;
+    return text
+        .splitLines(Yes.keepTerminator)[n-1..$]
+        .join;
+}
+
+/*******************************************************************************
+
     Runs a command and returns the output
 
     Params:
-        command = command to run
+        command = command and arguments to run (as a list)
+
+    Returns:
+        output of the command
+
+*******************************************************************************/
+
+string cmd ( const(string[]) command )
+{
+    import std.process : execute;
+    import std.string : strip;
+
+    auto c = execute(command);
+
+    if (c.status != 0)
+        throw new ExitCodeException(c.output, c.status);
+
+    return strip(c.output);
+}
+
+/*******************************************************************************
+
+    Runs a command and returns the output
+
+    Params:
+        command = command and arguments to run (it will be split based on spaces)
 
     Returns:
         output of the command
@@ -46,15 +94,9 @@ class ExitCodeException : Exception
 
 string cmd ( string command )
 {
-    import std.process : executeShell;
-    import std.string : strip;
+    import std.string : split;
 
-    auto c = executeShell(command);
-
-    if (c.status != 0)
-        throw new ExitCodeException(c.output, c.status);
-
-    return strip(c.output);
+    return cmd(command.split);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Generally speaking, is very bad to execute commands using a shell, as all sort of attacks can be done by injecting further commands using shell tricks.

Unless something is really needed from the shell, a process should be spawn instead, and if a shell is really needed, the command passed should be properly escaped to make sure the shell doesn't do crazy shit.

It is also more wasteful as it will spawn an extra process (the shell) if it's unneeded.

This also adds the To: header to the e-mail and uses less confusing variable names for the e-mail body/payload.

I think it should fix #111, but I couldn't try it yet.