### PR TITLE
Change release notes format to include summary line

### DIFF
--- a/doc/library-contributor.rst
+++ b/doc/library-contributor.rst
@@ -37,11 +37,12 @@ The following procedure should be followed:
 
    The descriptions of changes should be written in the following form::
 
-     * `name.of.affected.module` [, `name.of.another.affected.module`]
+     ## Catchy, max 80 characters description of the change
 
-       One or more lines describing the changes made. Each of these description
-       lines should be at most 80 characters long and should be indented to the
-       level of the bullet above.
+     `name.of.affected.module` [, `name.of.another.affected.module`]
+
+     One or more lines describing the changes made. Each of these description
+     lines should be at most 80 characters long.
 
 3. Insert your descriptions into files in the library's ``relnotes`` folder,
    named as follows: ``<name>.<change-type>.md``:


### PR DESCRIPTION
In the old format, the "heading" for each change was the
names of the affected modules. This makes the compiled release
notes difficult to read, as the actual changes don't stand out.
The new format puts a summary of each change as the header,
making the whole file easier for humans to quickly parse.