### PR TITLE
Support specifying release metadata

### DIFF
--- a/src/release/main.d
+++ b/src/release/main.d
@@ -99,7 +99,7 @@ void main ( string[] params )
     auto myrelease = autodetectVersions(tags_with_prereleases);
     myrelease.metadata = opts.metadata;
 
-    sanityCheckMilestone(con, repo, myrelease.toString);
+    sanityCheckMilestone(con, repo, myrelease.toStringNoMetadata());
 
     ActionList list;
 

--- a/src/release/main.d
+++ b/src/release/main.d
@@ -97,6 +97,7 @@ void main ( string[] params )
     cmd("git remote update");
 
     auto myrelease = autodetectVersions(tags_with_prereleases);
+    myrelease.metadata = opts.metadata;
 
     sanityCheckMilestone(con, repo, myrelease.toString);
 

--- a/src/release/options.d
+++ b/src/release/options.d
@@ -35,6 +35,9 @@ struct Options
     bool no_send_mail = false;
 
     bool pre_release;
+
+    /// metadata to be appended to the version
+    string metadata;
 }
 
 
@@ -76,7 +79,9 @@ Options parseOpts ( string[] opts )
            "pre-release|p", "Creates a release candidate (pre-release)",
            &options.pre_release,
            "no-send-mail", "When set, will not send the release email",
-           &options.no_send_mail);
+           &options.no_send_mail,
+           "metadata|m", "When set, will be appended to version as metadata string",
+           &options.metadata);
 
     if (verbose)
         options.logging = options.logging.trace;

--- a/src/semver/Version.d
+++ b/src/semver/Version.d
@@ -65,6 +65,24 @@ struct Version
     }
 
     /**
+        Returns:
+            string representation of the version stripped from
+            and metadata information
+     **/
+    string toStringNoMetadata ( ) const pure
+    {
+        import std.format;
+
+        if (!this.valid())
+            return "<invalid>";
+
+        return format(
+            "v%s.%s.%s%s", this.major, this.minor, this.patch,
+            this.prerelease.length ? "-" ~ this.prerelease : ""
+        );
+    }
+
+    /**
         Parses version string of form vX.Y.Z
 
         Params:


### PR DESCRIPTION
Checked with current ocean v3.x.x, seems to do what intended:

```
$ neptune-release -m breaking
...
We are on branch v3.x.x
Detected release v3.6.0
Warning: Corresponding milestone still has 3 open issues!
Actions to be done:
 * Creating annotated tag v3.6.0+breaking (git tag -F- v3.6.0+breaking v3.x.x)
 * Create tracking branch v3.6.x (git branch v3.6.x v3.6.0+breaking)
 * Removing release notes (...)
 * Commiting removal of release notes (git commit -m Clear release notes after release)
 * Checkout original branch v3.x.x (git checkout v3.x.x)
 ```