### PR TITLE
Merge commits are getting broken PGP signature texts

### DIFF
--- a/src/release/releaseHelper.d
+++ b/src/release/releaseHelper.d
@@ -72,7 +72,9 @@ class ReleaseAction : Action
 
         // Patch versions don't get release notes (yet)
         if (tag_version.patch > 0)
-            tag_msg = tag_version.toString;
+            // Messages must end with a new-line to avoid conflicting with GPG
+            // signatures
+            tag_msg = tag_version.toString ~ "\n";
         else
         {
             tag_msg = buildReleaseNotes(prev_tag, prev_relnotes);


### PR DESCRIPTION
This seems like a regression.

See for example: https://github.com/sociomantic-tsunami/cachalot/commit/0c6971982adb2af10de7417b9d871ead7c1f0aad

```
    Merge tag v4.0.1 into v4.x.x
    v4.0.1-----BEGIN PGP SIGNATURE-----
    Version: GnuPG v1
    
    iQIcBAABCAAGBQJalEppAAoJEOPQILQNRairmKcP/2jj47T7AK8YKrhImXzzrV28
    2QL0lqEaakhQkLFGloj3thCS7fsJIuAatflCks0BLEYHMAAHbPT9goiTPszYu3YF
    kDcVamcKhtEGPysp0oTHy6P8H24gkyvEDCOAi4aKFl7YfsbpdhhSH4Zbk/sLyUO5
    Mi17IvK7/WM3VOAJTAERusJsJLlVT/UjRrybKH1ED2lxzNIg7SKVUkPpaPunnFar
    iHb5pFzL4U5byv97AayyAcy/i/+F5q222c4xnkimGPaee4ka4sZT8lnfJGkwJCne
    SFZBP1CtpySjGwWgKHBK+1oKvTq0CGSWzZBdxDfdZTS5sUDbVsDO8kp4Pn8Phgpe
    Pbr6juSK2odWF0oVoxupc0PQGPAd8d7nI/Kpow8Fmej5+idUUvAlQ4bET/gWBH7b
    821kQsYBwabDS5cH/3ln93WsjAgBp2zeBP2fTbxRsRi/d8+LqY0H9wUUVeBIDiyT
    NhwC6UAXKgPeuDQ1VT38uNFBmeR26nIdCnwMD+Pbk1wCTXYYGEQOKBvLOSfPxDNx
    qDVwm5Zm3wnhLtgcgAdzA+EB+KsLShdb93ssa9517yossOrHA69cYDkT3jo1mhmG
    u5IqCpgdXcY6OT1oA+NrgLlkCmPpC4CmZEnkyWouec7ah1ouaUoAhpDhvuA3o7Hw
    EduEy+NFgkdQwKa/kjP7
    =cXm2
    -----END PGP SIGNATURE-----
    
    * tag 'v4.0.1':
      Don't push all tags of a certain image
```

This makes `v4.0.1-----BEGIN PGP SIGNATURE-----` the tag title, which is clearly wrong.

FYI, I'm using `git config commit.gpgSign true` and `git config tag.forceSignAnnotated true`.

I'm setting this as high prio because it's screwing repos history for ever.