### PR TITLE
Fix docker install script

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -1,4 +1,5 @@
 #!/bin/sh
 set -xeu
 
+apt-get update
 apt-get install -y libevent-dev libssl-dev


### PR DESCRIPTION
We need to do an update before doing the install to get the latest list
of package versions available.