### PR TITLE
Some merge messages still miss \n terminators

### DIFF
--- a/src/release/mergeHelper.d
+++ b/src/release/mergeHelper.d
@@ -34,8 +34,7 @@ class MergeAction : LocalAction
         import std.format;
         import colorize;
 
-        super(["git", "merge", "--no-ff", "-m",
-                format("Merge tag %s into %s", tag, target), tag],
+        super(["git", "merge", "--no-ff", "--no-edit", tag],
                 format("%s %s %s %s",
                      "Merge".color(fg.green),
                      tag.color(fg.green, bg.init, mode.bold),


### PR DESCRIPTION
Running `neptune-release` on cachalot now gets you a merge commit like:

```
commit 3ab3946000f4558835895a6d959157377443a33e (tag: v4.1.0-rc.1, v4.x.x)
Merge: 0c69719 fb49cf8
Author: Leandro Lucarella <leandro.lucarella@sociomantic.com>
Date:   Mon Mar 5 18:52:20 2018 +0100

    Merge tag v3.3.0-rc.1 into v4.x.x
    Features
    --------
    
    ### Add extra docker build arguments
[...]
```

Since there is no `\n` between `Merge ...` and `Features`, all is interpreted as the commit title (`Merge tag v3.3.0-rc.1 into v4.x.x Features --------`) and it's show like that when using, for example, `git log --oneline`.