### PR TITLE
Add consistent version headers to release notes

### DIFF
--- a/integrationtest/common/TestCase.d
+++ b/integrationtest/common/TestCase.d
@@ -304,7 +304,8 @@ class TestCase
         assert(!content[1].empty);
 
         auto test_mail = content[0];
-        auto correct_mail = readText(data ~ "/" ~ file).linesFrom(2);
+        auto path = data ~ "/" ~ file;
+        auto correct_mail = readText(path).linesFrom(2);
         if (test_mail != correct_mail)
         {
             import std.stdio;
@@ -314,6 +315,7 @@ class TestCase
             writeln("--------------------- good -------------------------");
             write(correct_mail);
             writeln("--------------------- end --------------------------");
+            writefln("Read from: %s", path);
             assert(false);
         }
     }

--- a/integrationtest/common/TestCase.d
+++ b/integrationtest/common/TestCase.d
@@ -251,7 +251,18 @@ class TestCase
 
             auto test_relnotes = strip(gh_rel.front.content);
 
-            assert(correct_relnotes == test_relnotes);
+            if (correct_relnotes != test_relnotes)
+            {
+                import std.stdio;
+                writeln("Generated release notes are incorrect");
+                writeln("--------------------- bad --------------------------");
+                write(test_relnotes);
+                writeln("--------------------- good -------------------------");
+                write(correct_relnotes);
+                writeln("--------------------- end --------------------------");
+                writefln("Read from: %s", path);
+                assert(false);
+            }
             assert(gh_rel.front.prerelease == (ver.prerelease.length > 0));
         }
 

--- a/integrationtest/common/data/relnotes.md
+++ b/integrationtest/common/data/relnotes.md
@@ -1,3 +1,6 @@
+Changes in v1.0.0-rc.1
+======================
+
 Migration Instructions
 ----------------------
 

--- a/integrationtest/prerelease/data/relnotes.rc.1.md
+++ b/integrationtest/prerelease/data/relnotes.rc.1.md
@@ -1,5 +1,5 @@
-Inherited changes from v1.1.0-rc.1
-==================================
+Changes in v1.0.0-rc.1
+======================
 
 Migration Instructions
 ----------------------


### PR DESCRIPTION
Release notes for a particular tag are missing a heading for the main release notes (the ones that are not inherited). To make notes more consistent, we always add a header with the specific versions the following notes are, so inherited notes will also get this very same header.

While at it, we stop passing around the inherited notes to `buildReleaseNotes()`, as they are required also outside of that function.