### PR TITLE
Fix autopr D2 update behavior

### DIFF
--- a/src/autopr/main.d
+++ b/src/autopr/main.d
@@ -604,14 +604,7 @@ void processSubmodules ( Json edge, LibInfo lib_info, RequestLevel global,
             continue;
         }
 
-        bool d2_only = false;
-
-        if (!meta_info.neptune_yaml.isNull() &&
-            meta_info.neptune_yaml.containsKey("d2ready") &&
-            meta_info.neptune_yaml["d2ready"] == "only")
-        {
-            d2_only = true;
-        }
+        bool d2_only = cur_ver.front.ver.metadata.canFind("d2");
 
         bool matchRequestLevel ( LibInfo.Release rel )
         {


### PR DESCRIPTION
Instead of using the repository D2 setting, use the existing submodule
policy, that is, if it is D2, keep it D2, if it isn't, don't

This fixes updates for non-d related submodules like makd