### PR TITLE
Don't reject all metadata when releasing

### DIFF
--- a/src/release/mergeHelper.d
+++ b/src/release/mergeHelper.d
@@ -393,7 +393,7 @@ class PatchMerger
             .retro.find!(a=>a.minor == br.minor &&
                          a.major == br.major &&
                          a.prerelease.length == 0 &&
-                         a.metadata.length == 0);
+                         !a.metadata.canFind("d2"));
 
 
         // A minor branch MUST have a release


### PR DESCRIPTION
When looking for first minor release previous logic would skip all tags
with metadata (with intention to ignore +d2 tags). However, anything
other than +d2 should be accepted.