### PR TITLE
autopr: Print the query string too if the query fails

### DIFF
--- a/src/autopr/main.d
+++ b/src/autopr/main.d
@@ -174,13 +174,13 @@ void main ( string[] args )
 
         more_pages = false;
 
+        scope(failure)
+            writefln("QUERY WAS: \n\n%s", query);
+
         auto qresult = con.graphQL(query);
 
         scope(failure)
-        {
-            writefln("QUERY WAS: \n\n%s", query);
             writefln("RESP WAS: \n\n%s", qresult);
-        }
 
         if ("errors" in qresult)
         {


### PR DESCRIPTION
The `scope (failure)` to print the query was done after the query was done, so no query string is printed when what fails is the query itself.