### PR TITLE
Add listing of all open pull requests sorted by open time

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -8,7 +8,7 @@ endif
 
 # Binaries and packaging
 
-tools := overview release autopr dfm
+tools := overview release autopr dfm time_open
 
 # Generate short aliases for the tools targets so one can use `make <tool>`
 define makealias =

--- a/dub.sdl
+++ b/dub.sdl
@@ -10,5 +10,6 @@ subPackage "src/overview"
 subPackage "src/release"
 subPackage "src/autopr"
 subPackage "src/data_flow_mapper"
+subPackage "src/time_open"
 
 subPackage "tests"

--- a/src/provider/api/repos/ReposGithub.d
+++ b/src/provider/api/repos/ReposGithub.d
@@ -290,6 +290,7 @@ class GithubRepo : Repository
         import std.format;
         import std.algorithm.iteration : map;
         import std.array;
+        import std.conv : to;
 
         return this.connection
             .get(format("/repos/%s/%s/issues?state=%s", this.login, this.name,

--- a/src/provider/api/repos/ReposGitlab.d
+++ b/src/provider/api/repos/ReposGitlab.d
@@ -289,12 +289,14 @@ class GitlabRepo : Repository
     /// Convert milestone state name to gitlab convention
     protected string convertState ( Milestone.State state )
     {
+        import std.conv : to;
         return state == state.open ? "active" : state.to!string;
     }
 
     /// Convert issue state name to gitlab convention
     protected string convertState ( Issue.State state )
     {
+        import std.conv : to;
         return state == state.open ? "opened" : state.to!string;
     }
 }

--- a/src/provider/core.d
+++ b/src/provider/core.d
@@ -191,6 +191,15 @@ struct HTTPConnection
     }
 
     /**
+        Disconnects from the GitHub API server
+     **/
+    void disconnect ( )
+    {
+        assert(this.connection !is null);
+        this.connection.disconnect();
+    }
+
+    /**
         Sends GET request to API server
 
         Params:

--- a/src/release/main.d
+++ b/src/release/main.d
@@ -987,6 +987,7 @@ Version autodetectVersions ( Version[] tags )
     }
     catch (Exception exc)
     {
+        import std.format : format;
         throw new Exception(format("Error: %s‚ Currently checked out branch" ~
             "\"%s\" is not SemVer compatible!", exc.msg, getCurrentBranch()));
     }

--- a/src/time_open/dub.sdl
+++ b/src/time_open/dub.sdl
@@ -1,0 +1,10 @@
+name         "time_open"
+description  ""
+authors      "dunnhumby Germany GmbH"
+copyright    "Copyright © 2019, dunnhumby Germany GmbH"
+license      "BSL-1.0"
+
+targetPath     "../../build/dub/bin"
+targetName     "time_open"
+sourcePaths    "."
+importPaths    ".."

--- a/src/time_open/dub.sdl
+++ b/src/time_open/dub.sdl
@@ -1,5 +1,5 @@
 name         "time_open"
-description  ""
+description  "Neptune time for open pull requests tool"
 authors      "dunnhumby Germany GmbH"
 copyright    "Copyright © 2019, dunnhumby Germany GmbH"
 license      "BSL-1.0"
@@ -8,3 +8,6 @@ targetPath     "../../build/dub/bin"
 targetName     "time_open"
 sourcePaths    "."
 importPaths    ".."
+
+dependency "internal" path="../internal"
+dependency "provider" path="../provider"

--- a/src/time_open/main.d
+++ b/src/time_open/main.d
@@ -2,6 +2,9 @@
 
     Main file
 
+    Lists the pull requests of a GitHub repository sorted by the time they are
+    open.
+
     Copyright:
         Copyright (c) 2019 dunnhumby Germany GmbH. All rights reserved.
 
@@ -20,10 +23,221 @@ module time_open.main;
     Params:
         args = command line arguments
 
+    Returns:
+        the exit status to the operating system
+
 *******************************************************************************/
 
 version(unittest) {} else
 int main ( string[] args )
 {
-    return 0;
+    // parse configuration from arguments
+    Config config = parseArgs(args);
+
+    import provider.core;
+    Configuration cfg;
+    cfg.platform = cfg.platform.Github;
+
+    // set up GitHub credentials
+    // preferring GitHub token
+    if (config.github_token.length)
+    {
+        cfg.oauthToken = config.github_token;
+    }
+    else
+    {
+        assert(config.username.length);
+
+        import core.sys.linux.unistd : getpass;
+        import std.string : fromStringz;
+        // FIXME
+        // getpass is obsolete
+        auto password = getpass("Password: ".ptr).fromStringz().idup;
+
+        cfg.username = config.username;
+        cfg.password = password;
+    }
+
+    auto http_connection = HTTPConnection.connect(cfg);
+    scope (exit)
+    {
+        http_connection.disconnect();
+    }
+
+    // GraphQL query for getting latest open PRs
+    enum query_format_string = `
+    {
+        repository(owner: "%s", name: "%s")
+        {
+            pullRequests(states: [OPEN],
+                         orderBy: {field: CREATED_AT, direction: ASC},
+                         last: %s)
+            {
+                nodes
+                {
+                    title
+                    url
+                    createdAt
+                }
+            }
+        }
+    }`;
+
+    import std.format : format;
+    auto query = query_format_string.format(config.owner, config.repository,
+        config.num_pull_requests);
+
+    import internal.github.graphql : graphQL;
+    auto result = http_connection.graphQL(query);
+    import std.stdio;
+    scope(failure)
+    {
+        stderr.writefln("Failed query: \n%s", query);
+        stderr.writefln("with response: \n%s", result);
+    }
+
+    if ("errors" in result)
+    {
+        auto err = result["errors"];
+        throw new Exception(err.get!(string)());
+    }
+
+    // extract pull requests
+    auto latest_open_prs = result["data"]["repository"]["pullRequests"]["nodes"];
+
+    import std.datetime : Clock;
+    import std.datetime.timezone : UTC;
+    auto now = Clock.currTime(UTC());
+    import core.time : Duration;
+    now.fracSecs = Duration.zero();
+
+    // sort pull requests since they are open and outputs them
+    import std.algorithm : map, sort, each;
+    import std.array : array;
+    import std.typecons : tuple;
+    import std.datetime : SysTime;
+    latest_open_prs.byValue()
+                   .map!(pr => tuple!("title", "url", "time_since_open")
+                                     (pr["title"].get!(string)(),
+                                      pr["url"].get!(string)(),
+                                      now - SysTime.fromISOExtString(pr["createdAt"].get!(string)())))()
+                   .array()
+                   .sort!((a,b) => a.time_since_open > b.time_since_open)()
+                   .each!(pr => writefln("PR '%s' (%s) open since %s",
+                           pr.title, pr.url, pr.time_since_open))();
+
+    import core.stdc.stdlib : EXIT_SUCCESS;
+    return EXIT_SUCCESS;
+}
+
+
+/// Configuration for querying pull requests from GitHub
+struct Config
+{
+    /// Username for GitHub authentication
+    string username = "";
+
+    /// GitHub OAuth token for authentication
+    string github_token = "";
+
+    /// GitHub repository owner to query the repository for
+    string owner = "sociomantic";
+
+    /// GitHub repository to query for
+    string repository = "";
+
+    /// Number of last open pull requests to query for
+    uint num_pull_requests = 5;
+}
+
+
+/*******************************************************************************
+
+    Parses the config from program arguments
+
+    Calls exit in case of errors with parsing arguments (EXIT_FAILURE) or if
+    program help was requested (EXIT_SUCCESS).
+
+    Params:
+        args = arguments to parse
+
+    Returns:
+        the successfully parsed config
+
+*******************************************************************************/
+
+private Config parseArgs ( string[] args )
+{
+    void exit ( int exit_status, string message = "")
+    {
+        // require a failure message
+        import core.stdc.stdlib : EXIT_SUCCESS;
+        assert(exit_status == EXIT_SUCCESS || message.length);
+        import std.stdio;
+        stderr.writeln(message);
+        import core.stdc.stdlib : exit;
+        exit(exit_status);
+        assert(false);
+    }
+    import core.stdc.stdlib : EXIT_FAILURE, EXIT_SUCCESS;
+
+    Config config;
+    import std.getopt;
+    GetoptResult help_info;
+    try
+    {
+        import std.format : format;
+        // filter options from arguments
+        help_info = getopt(args,
+            "username",
+            "Username for GitHub authentication asking later for a password",
+            &config.username,
+
+            "token",
+            "token for GitHub authentication",
+            &config.github_token,
+
+            "num-pull-requests",
+            "Maximal number of last open pull requests to fetch (defaults to %s)".format(
+                config.num_pull_requests),
+            &config.num_pull_requests,
+
+            "owner",
+            "Owner of the repository (defaults to %s)".format(
+                config.owner),
+            &config.owner,
+        );
+    }
+    catch (Exception e)
+    {
+        exit(EXIT_FAILURE, e.msg);
+    }
+
+    void printUsage ()
+    {
+        import std.format : format;
+        string desc = "Usage: %s [OPTION]... REPOSITORY\n\nLists GitHub pull requests longest in review.\n\nOptions:".format(args[0]);
+        defaultGetoptPrinter(desc, help_info.options);
+    }
+
+    if (help_info.helpWanted)
+    {
+        printUsage();
+        exit(EXIT_SUCCESS);
+    }
+
+    if (!config.username.length && !config.github_token.length)
+    {
+        exit(EXIT_FAILURE,
+            "Either username or token must be specified for GitHub authentication.");
+    }
+
+    if (args.length != 2)
+    {
+        exit(EXIT_FAILURE,
+            "Missing GitHub repository name.");
+    }
+    config.repository = args[1];
+
+    return config;
 }

--- a/src/time_open/main.d
+++ b/src/time_open/main.d
@@ -1,0 +1,29 @@
+/*******************************************************************************
+
+    Main file
+
+    Copyright:
+        Copyright (c) 2019 dunnhumby Germany GmbH. All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module time_open.main;
+
+
+/*******************************************************************************
+
+    Main function
+
+    Params:
+        args = command line arguments
+
+*******************************************************************************/
+
+version(unittest) {} else
+int main ( string[] args )
+{
+    return 0;
+}

--- a/src/time_open/main.d
+++ b/src/time_open/main.d
@@ -28,7 +28,13 @@ module time_open.main;
 
 *******************************************************************************/
 
-version(unittest) {} else
+version(unittest)
+{
+    void main ( string[] args )
+    {
+    }
+}
+else
 int main ( string[] args )
 {
     // parse configuration from arguments


### PR DESCRIPTION
This implements the command `time_open`. It will output the list of open
pull requests for a repository sorted by open time. This is implemented
by performing a GraphQL query against the GitHub API service and sorting
the output.