### PR TITLE
Fix travis builds: Increase timeout of neptune tests to 30 seconds

### DIFF
--- a/tests/common/TestCase.d
+++ b/tests/common/TestCase.d
@@ -208,7 +208,7 @@ class TestCase
         Any desired additional parameters can simply be passed as strings to
         this function.
 
-        If the instance is running for more than 10 seconds, it will be
+        If the instance is running for more than 30 seconds, it will be
         force-killed and this.killed will be set to true.
 
         Params:
@@ -239,7 +239,7 @@ class TestCase
 
         this.neptune_pid = neptune.pid;
 
-        setTimer(10.seconds, &this.neptuneTimeout);
+        setTimer(30.seconds, &this.neptuneTimeout);
 
         this.neptune_release_output.stdout =
             getAsyncStream(neptune.stdout);

--- a/tests/common/TestCase.d
+++ b/tests/common/TestCase.d
@@ -254,7 +254,7 @@ class TestCase
     protected void neptuneTimeout ( )
     {
         kill(this.neptune_pid);
-        this.failed = true;
+        this.killed = true;
     }
 
     /// Validates the release notes in github


### PR DESCRIPTION
The travis build runs now exceed the current 10 second limit.

Similarly, have fixed the timeout callback to set `this.killed = true` as per the code documentation.  If this was done in the first place, it would have saved a lot of debugging done to work out what the original cause was.