### PR TITLE
Adjust for deprecations and errors in 2.091, update CI matrix

### DIFF
--- a/.github/workflows/autopr.yml
+++ b/.github/workflows/autopr.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup dlang environment
       uses: dlang-community/setup-dlang@v1
       with:
-        compiler: dmd-2.084.1
+        compiler: dmd-2.091.1
 
     # Checks-out the neptune repository under $GITHUB_WORKSPACE
     - name: Checkout sociomantic-tsunami/neptune

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,14 +49,18 @@ jobs:
         - <<: *test-matrix
           env: DMD=2.080.*
         - <<: *test-matrix
-          env: DMD=2.081.*
+          env: DMD=2.085.*
+        - <<: *test-matrix
+          env: DMD=2.091.*
         - <<: *test-matrix
           env: DIST=bionic DMD=2.080.*
         - <<: *test-matrix
-          env: DIST=bionic DMD=2.081.*
+          env: DIST=bionic DMD=2.085.*
+        - <<: *test-matrix
+          env: DIST=bionic DMD=2.091.*
 
         # Package matrix
         - <<: *package-matrix
-          env: DMD=2.081.*
+          env: DMD=2.091.*
         - <<: *package-matrix
-          env: DIST=bionic DMD=2.081.*
+          env: DIST=bionic DMD=2.091.*

--- a/src/autopr/LibInfo.d
+++ b/src/autopr/LibInfo.d
@@ -163,7 +163,7 @@ struct LibInfo
 
                 import autopr.yaml;
 
-                auto rslt = getSupportGuarantees(meta.neptune_yaml);
+                auto rslt = getSupportGuarantees(meta.neptune_yaml.get);
 
                 // Skip non-library projects
                 if (!rslt.library)
@@ -351,8 +351,8 @@ struct LibInfo
             with (next.front)
             {
                 maj.support_end = published;
-                maj.support_end.add!"months"(maintained_major_months);
-                maj.supported = maj.support_end >= cast(Date) Clock.currTime();
+                maj.support_end.get.add!"months"(maintained_major_months);
+                maj.supported = maj.support_end.get >= cast(Date) Clock.currTime();
             }
         }
 

--- a/src/autopr/SubModsUpdate.d
+++ b/src/autopr/SubModsUpdate.d
@@ -185,10 +185,10 @@ as described in the [documentation](https://github.com/sociomantic-tsunami/neptu
         else
         {
             writefln("%s> Adding comment to PR %s (%s)",
-                this.repo, this.pr_number, this.release_candidates);
+                this.repo, this.pr_number.get, this.release_candidates);
 
             auto pr = con.updatePullrequest(this.repo.owner, this.repo.name,
-                this.pr_number, PRTitles[this.release_candidates], content);
+                this.pr_number.get, PRTitles[this.release_candidates], content);
 
             auto msg = format("This PR has been updated: \n\n%s",
                 pr_msg_part);

--- a/src/autopr/main.d
+++ b/src/autopr/main.d
@@ -450,7 +450,7 @@ auto findUpdates ( Json repo_edges, LibInfo lib_info, MetaInfo meta_info,
             import autopr.yaml;
 
             auto res =
-                getAutoPRSettings(meta.neptune_yaml);
+                getAutoPRSettings(meta.neptune_yaml.get);
 
             global = res.global;
             mods   = res.mods;

--- a/src/data_flow_mapper/main.d
+++ b/src/data_flow_mapper/main.d
@@ -189,9 +189,9 @@ void main ( string[] args )
         if (!mi.neptune_yaml.isNull)
         {
             writefln("Parsing %s yml", repo);
-            parseFromYML(mi.neptune_yaml, channels, connections, apps);
+            parseFromYML(mi.neptune_yaml.get, channels, connections, apps);
         }
-        //writefln("%s: \n%s\n----", repo, mi.neptune_yaml);
+        //writefln("%s: \n%s\n----", repo, mi.neptune_yaml.get);
     }
 
     enum FileName = "dataflow.gv";

--- a/src/internal/shell/helper.d
+++ b/src/internal/shell/helper.d
@@ -334,7 +334,7 @@ void keepTrying ( void delegate ( ) dg, int max_attempts, Duration wait_time,
     auto tryWritefln ( Args... ) ( Nullable!File stream, Args args )
     {
         if (!stream.isNull)
-            stream.writefln(args);
+            stream.get.writefln(args);
     }
 
     foreach (_; 0..max_attempts) try

--- a/src/provider/api/repos/ReposGithub.d
+++ b/src/provider/api/repos/ReposGithub.d
@@ -290,6 +290,7 @@ class GithubRepo : Repository
         import std.format;
         import std.algorithm.iteration : map;
         import std.array;
+        import std.conv;
 
         return this.connection
             .get(format("/repos/%s/%s/issues?state=%s", this.login, this.name,

--- a/src/provider/api/repos/ReposGitlab.d
+++ b/src/provider/api/repos/ReposGitlab.d
@@ -289,12 +289,14 @@ class GitlabRepo : Repository
     /// Convert milestone state name to gitlab convention
     protected string convertState ( Milestone.State state )
     {
+        import std.conv;
         return state == state.open ? "active" : state.to!string;
     }
 
     /// Convert issue state name to gitlab convention
     protected string convertState ( Issue.State state )
     {
+        import std.conv;
         return state == state.open ? "opened" : state.to!string;
     }
 }

--- a/src/release/main.d
+++ b/src/release/main.d
@@ -893,7 +893,7 @@ SemVerBranch[] getBranches ( ref HTTPConnection con, ref Repository repo,
     bool thisVersion ( SemVerBranch v )
     {
         return v.major == ver.major &&
-               !v.minor.isNull && v.minor == ver.minor;
+               !v.minor.isNull && v.minor.get == ver.minor;
     }
 
     bool newerVersion ( SemVerBranch v )
@@ -1014,7 +1014,7 @@ Version autodetectVersions ( Version[] tags )
     {
         if (current.minor.isNull ||
             a.major != current.major ||
-            a.minor != current.minor)
+            a.minor != current.minor.get)
             return false;
 
         if (!options.pre_release && a.prerelease.length > 0)

--- a/src/release/main.d
+++ b/src/release/main.d
@@ -977,6 +977,7 @@ Version autodetectVersions ( Version[] tags )
     import std.range;
     import std.algorithm;
     import std.exception : enforce;
+    import std.format : format;
 
     SemVerBranch current;
 

--- a/src/release/versionHelper.d
+++ b/src/release/versionHelper.d
@@ -105,7 +105,7 @@ struct SemVerBranch
     {
         static int nullAs0 ( Nullable!int num )
         {
-            return num.isNull ? 0 : num;
+            return num.isNull ? 0 : num.get;
         }
 
         if (this.major != v.major)
@@ -140,7 +140,7 @@ struct SemVerBranch
         if (this.minor.isNull)
             return 1;
 
-        return this.minor - v.minor;
+        return this.minor.get - v.minor;
     }
 
 
@@ -170,7 +170,7 @@ struct SemVerBranch
 
         return format("v%s.%s.x",
                       this.major,
-                      this.minor.isNull ? "x" : this.minor.to!string);
+                      this.minor.isNull ? "x" : this.minor.get.to!string);
     }
 
 
@@ -290,7 +290,7 @@ public bool needPatchRelease ( A, B ) ( A matching_major, B matching_minor,
     if (matching_minor.empty)
         return false;
 
-    new_version = Version(current.major, current.minor,
+    new_version = Version(current.major, current.minor.get,
                           matching_minor.front.patch+1);
 
     return true;


### PR DESCRIPTION
Now testing on 2.080, 2.085, and 2.091, a similar range that's used by Ocean.

There still a number of deprecations present, it looks like they all come from dependencies/library though.